### PR TITLE
Added star button functionality

### DIFF
--- a/idea.js
+++ b/idea.js
@@ -6,4 +6,8 @@ class Idea {
     this.star = false;
   }
 
+  toggleStar() {
+  this.star = !this.star;
+  }
+
 }

--- a/main.js
+++ b/main.js
@@ -36,11 +36,10 @@ function addPastIdea() {
 function makeCard(newIdea) {
   cardSection.insertAdjacentHTML('beforeend', `<div id="${newIdea.id}" class="card">
       <header>
-        <button class="card-button" type="button">
-          <img class="card-icon" src="images/star-active.svg" alt="Star icon"/>
+        <button class="card-button star-inactive" type="button" onclick= "starButton(event)">
         </button>
-        <button class="card-button" type="button">
-          <img class="card-icon" src="images/delete.svg" alt="Delete icon"/>
+        <button class="card-button delete-inactive" type="button">
+          <img class="card-icon delete" src="images/delete.svg" alt="Delete icon"/>
         </button>
       </header>
       <section class="card-content">
@@ -59,4 +58,18 @@ function makeCard(newIdea) {
 function clearForm() {
   bodyInput.value = "";
   titleInput.value = "";
+}
+
+function starButton(event) {
+  var cardId = event.target.closest('.card').id;
+  var starButton = document.querySelector('star')
+  var instance = ideaLog.find(function(idea){
+  return Number(idea.id) === Number(cardId);
+  })
+  instance.toggleStar();
+  if (!instance.star) {
+    event.target.classList.remove('star-active');
+  } else {
+    event.target.classList.add('star-active');
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -239,6 +239,26 @@ p {
   width: 100%;
 }
 
+.star-inactive {
+  background-image: url(images/star.svg);
+  background-repeat: no-repeat;
+  height: 36px;
+  width: 36px;
+  background-color: transparent;
+  padding-bottom: 7px;
+  border-color: transparent;
+}
+
+.star-active {
+  background-image: url(images/star-active.svg);
+  background-repeat: no-repeat;
+  height: 36px;
+  width: 36px;
+  background-color: transparent;
+  padding-bottom: 7px;
+  border-color: transparent;
+}
+
 @media only screen and (max-width: 1075px) {
 
   .starred {


### PR DESCRIPTION
Added star functionality by targeting the closest.'card'.id then iterated through our array to match our id from the constructor and from the id on the card on the Dom as well. After I found that specific card to target, I called the toggleStar method that lives in the idea.js that will toggle our star property between true and false. When false it will have the star-inactive class with the inactive image (by default) and when that property is toggled to true it will add the classList of star-active which has the active image as it's background and since it lives lower in css it will override the previous class and change the background image when that property toggles to true. When toggled from true to false it will then remove the classList of star-active and the previous inactive class will now take precedence. 